### PR TITLE
Flaky test

### DIFF
--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1023,7 +1023,7 @@ Upgrades::applyVersionUpgrade(AbstractLedgerTxn& ltx, uint32_t newVersion)
             value[n] = (unsigned char)n;
         }
 
-        std::string t1("test2");
+        std::string t1("test4");
 
         LedgerEntry newData;
         newData.data.type(DATA);

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1013,6 +1013,25 @@ Upgrades::applyVersionUpgrade(AbstractLedgerTxn& ltx, uint32_t newVersion)
     {
         upgradeFromProtocol15To16(ltx);
     }
+    else if (protocolVersionIsBefore(prevVersion, SOROBAN_PROTOCOL_VERSION) &&
+             protocolVersionStartsFrom(newVersion, SOROBAN_PROTOCOL_VERSION))
+    {
+        DataValue value;
+        value.resize(64);
+        for (int n = 0; n < 64; n++)
+        {
+            value[n] = (unsigned char)n;
+        }
+
+        std::string t1("test2");
+
+        LedgerEntry newData;
+        newData.data.type(DATA);
+        auto& dataEntry = newData.data.data();
+        dataEntry.dataName = t1;
+        dataEntry.dataValue = value;
+        ltx.create(newData);
+    }
 }
 
 void

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -2571,6 +2571,22 @@ TEST_CASE("upgrade to generalized tx set in network", "[upgrades][overlay]")
     {
         simulation->addConnection(addedKey.getPublicKey(), nodeID);
     }
+
+    /*
+    The test fails with this message because the node that was just added didn't
+    sync
+    -------------------------------------------------------------------------------
+    upgrade to generalized tx set in network
+    -------------------------------------------------------------------------------
+    herder/test/UpgradesTests.cpp:2496
+    ...............................................................................
+
+    herder/test/UpgradesTests.cpp:2563: FAILED:
+    {Unknown expression after the reported line}
+    due to unexpected exception with message:
+    Too wide spread between nodes: 12-1 > 10
+
+    */
     // Let the network to externalize 1 more ledger.
     simulation->crankUntil(
         [&]() { return simulation->haveAllExternalized(12, 10); },


### PR DESCRIPTION
# Description

The first commit adds an entry on upgrade to v20 that does not mess with the test case. The second commit breaks the test.
<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
